### PR TITLE
build: switch to Soldevelo container images (Bitnami access now paid)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   mongodb-bridgex:
-    image: docker.io/bitnami/mongodb:latest
+    image: docker.io/soldevelo/mongodb:latest
     container_name: mongodb-bridgex
     networks:
       - bridgex-network


### PR DESCRIPTION
## Switch container base images to SolDevelo

Bitnami images now require a VMware Tanzu subscription (change effective **August 28, 2025**). This causes pipeline failures and added cost for teams that relied on the public registry.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides drop-in replacements - same Debian-based images, same startup scripts, same environment-variable API - built openly from [SolDevelo/containers](https://github.com/SolDevelo/containers) and tagged to match Bitnami upstream.

## Image substitutions

- `bitnami/mongodb:latest` → [`soldevelo/mongodb:latest`](https://hub.docker.com/r/soldevelo/mongodb)